### PR TITLE
Updated README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 
 # elixir-wasm
 
-This package exports `WASM` and `WASM.Validation`.  Modules that compile and validate an AST that resembles [the WASM binary format](http://webassembly.github.io/spec/binary/).
+This package exports `WASM` and `WASM.Validation`.  Modules that compile and validate an AST that resembles [the WASM binary format](https://webassembly.github.io/spec/).
 


### PR DESCRIPTION
The link to the WebAssembly specs is no longer valid and gives me a 404. Changed it to the parent spec page and added https to get a valid link that points to the specs.